### PR TITLE
treewide: Use gitignore.nix for sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -15,17 +15,39 @@
         "type": "github"
       }
     },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "gomod2nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1662095654,
-        "narHash": "sha256-v2WMKnkpkz5YLYTBwh0NVgi3Xl4En249LCdrKTA4Nek=",
+        "lastModified": 1662501203,
+        "narHash": "sha256-4BKeqCX2zwgBiTdlc2DjGQ0CttKm0vSw0r/bdFdM/PQ=",
         "owner": "nix-community",
         "repo": "gomod2nix",
-        "rev": "cc75990c60d01d9eedcf32ff4bf0055dd49c3ea1",
+        "rev": "89cd0675b96775aa3ee86e7c0cf5bc238dd27976",
         "type": "github"
       },
       "original": {
@@ -35,22 +57,6 @@
       }
     },
     "nixpkgs": {
-      "locked": {
-        "lastModified": 1658285632,
-        "narHash": "sha256-zRS5S/hoeDGUbO+L95wXG9vJNwsSYcl93XiD0HQBXLk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "5342fc6fb59d0595d26883c3cadff16ce58e44f3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "master",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
       "locked": {
         "lastModified": 1662019588,
         "narHash": "sha256-oPEjHKGGVbBXqwwL+UjsveJzghWiWV0n9ogo1X6l4cw=",
@@ -86,8 +92,9 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "gitignore": "gitignore",
         "gomod2nix": "gomod2nix",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "npmlock2nix": "npmlock2nix"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,16 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    gomod2nix.url = "github:nix-community/gomod2nix";
+
+    gomod2nix = {
+      url = "github:nix-community/gomod2nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    gitignore = {
+      url = "github:hercules-ci/gitignore.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
 
     npmlock2nix = {
       url = "github:nix-community/npmlock2nix/master";

--- a/packages/trustix-doc/default.nix
+++ b/packages/trustix-doc/default.nix
@@ -1,12 +1,16 @@
 { pkgs ? import ../../pkgs.nix { }
 , lib ? pkgs.lib
+, gitignoreSource
 }:
 
 pkgs.stdenv.mkDerivation {
   pname = "trustix-doc";
   version = "dev";
 
-  src = lib.cleanSource ./.;
+  src = lib.cleanSourceWith {
+    filter = name: type: ! lib.hasSuffix "tests" name;
+    src = gitignoreSource ./.;
+  };
 
   nativeBuildInputs = [
     pkgs.mdbook

--- a/packages/trustix-nix-reprod/default.nix
+++ b/packages/trustix-nix-reprod/default.nix
@@ -1,4 +1,4 @@
-{ buildGoApplication, lib }:
+{ buildGoApplication, lib, gitignoreSource }:
 
 buildGoApplication {
   pname = "trustix-nix-reprod";
@@ -6,7 +6,7 @@ buildGoApplication {
   pwd = ./.;
   src = lib.cleanSourceWith {
     filter = name: type: ! lib.hasSuffix "tests" name;
-    src = lib.cleanSource ./.;
+    src = gitignoreSource ./.;
   };
   modules = ./gomod2nix.toml;
 }

--- a/packages/trustix-nix/cmd/binary-cache-proxy.go
+++ b/packages/trustix-nix/cmd/binary-cache-proxy.go
@@ -13,10 +13,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/bakins/logrus-middleware"
@@ -62,7 +62,7 @@ func getCaches(c interfaces.RpcAPI) ([]string, error) {
 }
 
 func readKey(path string) (string, crypto.Signer, error) {
-	keyBytes, err := ioutil.ReadFile(path)
+	keyBytes, err := os.ReadFile(path)
 	if err != nil {
 		panic(err)
 	}
@@ -218,7 +218,7 @@ var binaryCacheCommand = &cobra.Command{
 								continue
 							}
 
-							narinfoBytes, err := ioutil.ReadAll(resp.Body)
+							narinfoBytes, err := io.ReadAll(resp.Body)
 							if err != nil {
 								panic(err)
 							}

--- a/packages/trustix-nix/cmd/lib.go
+++ b/packages/trustix-nix/cmd/lib.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base32"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -29,7 +28,7 @@ func createKVPair(storePath string) (*api.KeyValuePair, error) {
 		return nil, fmt.Errorf("Empty input store path")
 	}
 
-	tmpDir, err := ioutil.TempDir("", "nix-trustix")
+	tmpDir, err := os.MkdirTemp("", "nix-trustix")
 	if err != nil {
 		return nil, err
 	}

--- a/packages/trustix-nix/cmd/post-build-hook.go
+++ b/packages/trustix-nix/cmd/post-build-hook.go
@@ -6,7 +6,6 @@
 package cmd
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"sync"
@@ -39,7 +38,7 @@ var nixHookCommand = &cobra.Command{
 		wg := new(sync.WaitGroup)
 		mux := new(sync.Mutex)
 
-		tmpDir, err := ioutil.TempDir("", "nix-trustix")
+		tmpDir, err := os.MkdirTemp("", "nix-trustix")
 		if err != nil {
 			return err
 		}

--- a/packages/trustix-nix/default.nix
+++ b/packages/trustix-nix/default.nix
@@ -1,4 +1,4 @@
-{ buildGoApplication, lib, pkg-config }:
+{ buildGoApplication, lib, pkg-config, gitignoreSource }:
 
 buildGoApplication {
   pname = "trustix_nix";
@@ -8,7 +8,7 @@ buildGoApplication {
 
   src = lib.cleanSourceWith {
     filter = name: type: ! lib.hasSuffix "tests" name;
-    src = lib.cleanSource ./.;
+    src = gitignoreSource ./.;
   };
 
   modules = ./gomod2nix.toml;

--- a/packages/trustix/default.nix
+++ b/packages/trustix/default.nix
@@ -1,4 +1,4 @@
-{ buildGoApplication, lib, pkg-config }:
+{ buildGoApplication, lib, pkg-config, gitignoreSource }:
 
 buildGoApplication {
   pname = "trustix";
@@ -8,7 +8,7 @@ buildGoApplication {
 
   src = lib.cleanSourceWith {
     filter = name: type: ! lib.hasSuffix "tests" name;
-    src = lib.cleanSource ./.;
+    src = gitignoreSource ./.;
   };
 
   modules = ./gomod2nix.toml;

--- a/packages/trustix/internal/cmd/generatekey.go
+++ b/packages/trustix/internal/cmd/generatekey.go
@@ -9,8 +9,8 @@ import (
 	"crypto/ed25519"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -42,12 +42,12 @@ var generateKeyCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		err = ioutil.WriteFile(generatePublicKeyOutput, []byte(base64.StdEncoding.EncodeToString(pub)), 0644)
+		err = os.WriteFile(generatePublicKeyOutput, []byte(base64.StdEncoding.EncodeToString(pub)), 0644)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		err = ioutil.WriteFile(generatePrivateKeyOutput, []byte(base64.StdEncoding.EncodeToString(priv)), 0644)
+		err = os.WriteFile(generatePrivateKeyOutput, []byte(base64.StdEncoding.EncodeToString(priv)), 0644)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/packages/trustix/internal/signer/lib.go
+++ b/packages/trustix/internal/signer/lib.go
@@ -7,11 +7,11 @@ package signer
 
 import (
 	"encoding/base64"
-	"io/ioutil"
+	"os"
 )
 
 func readKey(path string) ([]byte, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -3,7 +3,7 @@
 }:
 
 let
-  inherit (flakeInputs) nixpkgs gomod2nix npmlock2nix;
+  inherit (flakeInputs) nixpkgs gomod2nix npmlock2nix gitignore;
 in
 
 import nixpkgs {
@@ -11,6 +11,8 @@ import nixpkgs {
   config.allowAliases = false;
   overlays = [
     (import "${gomod2nix}/overlay.nix")
+
+    (final: prev: (import "${gitignore}" { inherit (final) lib; }))
 
     (final: prev: {
       # Prevent the entirety of hydra to be in $PATH/runtime closure


### PR DESCRIPTION
To reduce the rebuilds a bit.