### PR TITLE
Incorporate my work on trustix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ result*
 /state
 *.sqlite3
 __pycache__
+nixos.qcow2

--- a/examples/nixos-shell.nix
+++ b/examples/nixos-shell.nix
@@ -11,7 +11,7 @@ in
   #       so instead we copy over the overlays and config, but the pinned nixpkgs does not carry over here
   # nixpkgs.pkgs = import ../pkgs.nix {};
   nixpkgs = {
-    inherit (import ../pkgs.nix {}) overlays config;
+    inherit (import ../pkgs.nix { }) overlays config;
   };
 
   services.trustix = {

--- a/examples/nixos-shell.nix
+++ b/examples/nixos-shell.nix
@@ -7,7 +7,12 @@ in
     ../packages/trustix-nix/nixos
   ];
 
-  nixpkgs.pkgs = import ../pkgs.nix { };
+  # TODO: for some reason setting nixpkgs.pkgs directly causes problems with nixos-shell
+  #       so instead we copy over the overlays and config, but the pinned nixpkgs does not carry over here
+  # nixpkgs.pkgs = import ../pkgs.nix {};
+  nixpkgs = {
+    inherit (import ../pkgs.nix {}) overlays config;
+  };
 
   services.trustix = {
     enable = true;

--- a/packages/trustix-nix/nixos/binarycache.nix
+++ b/packages/trustix-nix/nixos/binarycache.nix
@@ -3,7 +3,7 @@
 let
   cfg = config.services.trustix-nix-cache;
 
-  inherit (lib) mkOption mkIf types optional literalExpression;
+  inherit (lib) mkOption mkIf types optional;
 
 in
 {
@@ -15,7 +15,7 @@ in
     package = mkOption {
       type = types.package;
       default = pkgs.trustix-nix;
-      defaultText = literalExpression "pkgs.trustix-nix";
+      defaultText = "pkgs.trustix-nix";
       description = "Which Trustix-Nix derivation to use.";
     };
 


### PR DESCRIPTION
- adds a `print-log-id` command so that you don't have to hunt through systemd logs to find the trustix log-id for your publisher
- introduces a `services.trustix-nix-build-hook.publisher` option that allows you to set it either via the logID or via the publisher config directly (taking advantage of the first one)
- updates the documentation to reflect this (and corrects a few minor mistakes)
- introduces a new example `examples/nixos-shell.nix` meant to be used with [nixos-shell](github.com/Mic92/nixos-shell). This can be invoked with `nix run github:Mic92/nixos-shell -- examples/nixos-shell.nix` and will drop you into a VM that has a trustix log running, and will publish to it when building nix derivations.