### PR TITLE
flake.nix: Use same flake-utils for every input

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,7 @@
     gomod2nix = {
       url = "github:nix-community/gomod2nix";
       inputs.nixpkgs.follows = "nixpkgs";
+      inputs.utils.follows = "flake-utils";
     };
 
     gitignore = {
@@ -18,6 +19,7 @@
     nix-eval-jobs = {
       url = "github:nix-community/nix-eval-jobs";
       inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
     };
 
     npmlock2nix = {


### PR DESCRIPTION
I noticed that the "nixpkgs" input of all of trustix's inputs are set to follow trustix's nixpkgs.
However, this isn't the case for flake-utils.
This PR aims to fix that inconsistency and to save a few extra copies/downloads of flake-utils.

If it has been left out by purpose though, please let me know / close this PR.

Thanks